### PR TITLE
Fix on pagination column count

### DIFF
--- a/build-output/_multiple-bundles/readium-shared-js.js
+++ b/build-output/_multiple-bundles/readium-shared-js.js
@@ -18888,7 +18888,7 @@ var ReaderView = function (options) {
 
         if (!ReadiumSDK) return;
 
-        var DEBUG = true; // change this to visualize the CFI range
+        var DEBUG = false; // change this to visualize the CFI range
         if (!DEBUG) return;
             
         var paginationInfo = this.getPaginationInfo();

--- a/build-output/_multiple-bundles/readium-shared-js.js
+++ b/build-output/_multiple-bundles/readium-shared-js.js
@@ -16867,21 +16867,6 @@ var ReflowableView = function(options, reader){
 
     }
 
-    function getOpenPageIndexes() {
-
-        var indexes = [];
-
-        var currentPage = _paginationInfo.currentSpreadIndex * _paginationInfo.visibleColumnCount;
-
-        for(var i = 0; i < _paginationInfo.visibleColumnCount && (currentPage + i) < _paginationInfo.columnCount; i++) {
-
-            indexes.push(currentPage + i);
-        }
-
-        return indexes;
-
-    }
-
     //we need this styles for css columnizer not to chop big images
     function resizeImages() {
 

--- a/build-output/_multiple-bundles/readium-shared-js.js
+++ b/build-output/_multiple-bundles/readium-shared-js.js
@@ -16826,6 +16826,21 @@ var ReflowableView = function(options, reader){
             return paginationInfo;
         }
 
+        // DEBUG Recalculate columnCount before sending paginationInfo
+        var dim = (_htmlBodyIsVerticalWritingMode ? _$epubHtml[0].scrollHeight : _$epubHtml[0].scrollWidth);
+        if (dim == 0) {
+            console.error("Document dimensions zero?!");
+            return paginationInfo;
+        }
+
+        _paginationInfo.columnCount = (dim + _paginationInfo.pageOffset + _paginationInfo.columnGap) / (_paginationInfo.columnWidth + _paginationInfo.columnGap);
+        _paginationInfo.columnCount = Math.round(_paginationInfo.columnCount);
+        if (_paginationInfo.columnCount == 0 || _paginationInfo.columnWidth == 0) {
+            console.error("Column count zero?!");
+            return paginationInfo;
+        }
+        // END Recalculate columnCount before sending paginationInfo
+
         var pageIndexes = getOpenPageIndexes();
 
         for(var i = 0, count = pageIndexes.length; i < count; i++) {
@@ -16836,6 +16851,21 @@ var ReflowableView = function(options, reader){
         return paginationInfo;
 
     };
+
+    function getOpenPageIndexes() {
+
+        var indexes = [];
+
+        var currentPage = _paginationInfo.currentSpreadIndex * _paginationInfo.visibleColumnCount;
+
+        for(var i = 0; i < _paginationInfo.visibleColumnCount && (currentPage + i) < _paginationInfo.columnCount; i++) {
+
+            indexes.push(currentPage + i);
+        }
+
+        return indexes;
+
+    }
 
     function getOpenPageIndexes() {
 

--- a/build-output/_single-bundle/readium-shared-js_all.js
+++ b/build-output/_single-bundle/readium-shared-js_all.js
@@ -45330,7 +45330,7 @@ var ReaderView = function (options) {
 
         if (!ReadiumSDK) return;
 
-        var DEBUG = true; // change this to visualize the CFI range
+        var DEBUG = false; // change this to visualize the CFI range
         if (!DEBUG) return;
             
         var paginationInfo = this.getPaginationInfo();

--- a/build-output/_single-bundle/readium-shared-js_all.js
+++ b/build-output/_single-bundle/readium-shared-js_all.js
@@ -43268,6 +43268,21 @@ var ReflowableView = function(options, reader){
             return paginationInfo;
         }
 
+        // DEBUG Recalculate columnCount before sending paginationInfo
+        var dim = (_htmlBodyIsVerticalWritingMode ? _$epubHtml[0].scrollHeight : _$epubHtml[0].scrollWidth);
+        if (dim == 0) {
+            console.error("Document dimensions zero?!");
+            return paginationInfo;
+        }
+
+        _paginationInfo.columnCount = (dim + _paginationInfo.pageOffset + _paginationInfo.columnGap) / (_paginationInfo.columnWidth + _paginationInfo.columnGap);
+        _paginationInfo.columnCount = Math.round(_paginationInfo.columnCount);
+        if (_paginationInfo.columnCount == 0 || _paginationInfo.columnWidth == 0) {
+            console.error("Column count zero?!");
+            return paginationInfo;
+        }
+        // END Recalculate columnCount before sending paginationInfo
+
         var pageIndexes = getOpenPageIndexes();
 
         for(var i = 0, count = pageIndexes.length; i < count; i++) {

--- a/js/views/reader_view.js
+++ b/js/views/reader_view.js
@@ -1037,7 +1037,7 @@ var ReaderView = function (options) {
 
         if (!ReadiumSDK) return;
 
-        var DEBUG = true; // change this to visualize the CFI range
+        var DEBUG = false; // change this to visualize the CFI range
         if (!DEBUG) return;
             
         var paginationInfo = this.getPaginationInfo();

--- a/js/views/reflowable_view.js
+++ b/js/views/reflowable_view.js
@@ -959,6 +959,22 @@ var ReflowableView = function(options, reader){
             return paginationInfo;
         }
 
+
+        // DEBUG Recalculate columnCount before sending paginationInfo
+        var dim = (_htmlBodyIsVerticalWritingMode ? _$epubHtml[0].scrollHeight : _$epubHtml[0].scrollWidth);
+        if (dim == 0) {
+            console.error("Document dimensions zero?!");
+            return paginationInfo;
+        }
+
+        _paginationInfo.columnCount = (dim + _paginationInfo.pageOffset + _paginationInfo.columnGap) / (_paginationInfo.columnWidth + _paginationInfo.columnGap);
+        _paginationInfo.columnCount = Math.round(_paginationInfo.columnCount);
+        if (_paginationInfo.columnCount == 0 || _paginationInfo.columnWidth == 0) {
+            console.error("Column count zero?!");
+            return paginationInfo;
+        }
+        // END Recalculate columnCount before sending paginationInfo
+
         var pageIndexes = getOpenPageIndexes();
 
         for(var i = 0, count = pageIndexes.length; i < count; i++) {


### PR DESCRIPTION
`onPaginationChanged` callback is called several times on pagination display. 
However, sometimes it's called with wrong `spineItemPageCount` and this cause issues in our Android app. 

I fixed this issue by recalculating `spineItemPageCount` just before calling `onPaginationChanged` in `reflow_view.js`. 